### PR TITLE
Add Cursor IDE compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Branch in Window Title VS Code Extension
 
-**Branch in Window Title** is a simple [Visual Studio Code](https://code.visualstudio.com) extension that looks for a Git repository in the currently open workspace. If a Git repository is detected, the current branch name is appended to the VS Code window title.
+**Branch in Window Title** is a simple [Visual Studio Code](https://code.visualstudio.com) and [Cursor](https://cursor.com) extension that looks for a Git repository in the currently open workspace. If a Git repository is detected, the current branch name is appended to the window title.
 
 ![VS Code Window Title](doc/resources/window-title.png)
 
@@ -55,6 +55,16 @@ The Jira Connector also watches Jira for new issues and automatically syncs them
 ### Many Connection Options
 
 Not using Jira? We offer many other types of [Connectors](https://wisetime.com/connectors/), including [Zapier](https://wisetime.com/zapier/). We also provide the [WiseTime Connect API](https://wisetime.com/docs/connect/), as well as a [WiseTime Connector Java Library](https://github.com/wisetime-io/wisetime-connector-java) that wraps the API. With these, you can easily implement your own custom connector.
+
+## Cursor IDE Compatibility
+
+This extension works in [Cursor](https://cursor.com), but Cursor's default custom title bar does not display the `window.title` setting. To use this extension with Cursor, switch to the native title bar by adding the following to your settings:
+
+```json
+"window.titleBarStyle": "native"
+```
+
+The extension will detect Cursor and offer to make this change automatically on first activation. After changing the title bar style, restart Cursor for the change to take effect.
 
 ## Extension Settings
 

--- a/src/cursorCompat.ts
+++ b/src/cursorCompat.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 WiseTime. All rights reserved.
+
+export interface NotificationDeps {
+  appName: string;
+  getTitleBarStyle: () => string | undefined;
+  getDismissed: () => boolean;
+  setDismissed: (value: boolean) => Thenable<void>;
+  setTitleBarStyle: (value: string) => Thenable<void>;
+  showInfo: (message: string, ...items: string[]) => Thenable<string | undefined>;
+}
+
+const SWITCH_ACTION = 'Use Native Title Bar';
+const DISMISS_ACTION = "Don't Show Again";
+
+export function shouldShowNotification(deps: NotificationDeps): boolean {
+  return deps.appName === 'Cursor'
+    && deps.getTitleBarStyle() !== 'native'
+    && !deps.getDismissed();
+}
+
+export default function showCursorTitleBarNotification(deps: NotificationDeps): void {
+  if (!shouldShowNotification(deps)) {
+    return;
+  }
+
+  deps.showInfo(
+    "Cursor's custom title bar does not display the window.title setting. " +
+    'Switch to the native title bar for the branch name to appear in the window title.',
+    SWITCH_ACTION,
+    DISMISS_ACTION,
+  ).then(selection => {
+    if (selection === SWITCH_ACTION) {
+      deps.setTitleBarStyle('native');
+      deps.showInfo(
+        'Title bar style set to native. Restart Cursor for the change to take effect.',
+      );
+    }
+    if (selection === SWITCH_ACTION || selection === DISMISS_ACTION) {
+      deps.setDismissed(true);
+    }
+  });
+}

--- a/src/cursorCompat.ts
+++ b/src/cursorCompat.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WiseTime. All rights reserved.
+// Copyright (c) 2026 WiseTime. All rights reserved.
 
 export interface NotificationDeps {
   appName: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,14 +3,16 @@
 import * as vscode from 'vscode';
 import detectBranch from './branchDetector';
 import updateTitle from './titleUpdater';
+import showCursorTitleBarNotification from './cursorCompat';
 
 const windowConfig = () => vscode.workspace.getConfiguration('window');
 const getWindowTitle = () => windowConfig().get('title') as string;
 const setWindowTitle = (title: string) => windowConfig().update('title', title);
 
+const CURSOR_COMPAT_DISMISSED_KEY = 'cursorTitleBarNotificationDismissed';
+
 export function activate(context: vscode.ExtensionContext) {
   if (!vscode.workspace.workspaceFolders) {
-    // No open project, no Git repository.
     return;
   }
   const pollingInterval = vscode.workspace
@@ -25,6 +27,15 @@ export function activate(context: vscode.ExtensionContext) {
 
   const branchDetector = detectBranch(vscode.workspace.workspaceFolders[0].uri, pollingInterval, updateTitle(getWindowTitle, setWindowTitle, branchTemplate, branchNameIsPrefix));
   context.subscriptions.push(branchDetector);
+
+  showCursorTitleBarNotification({
+    appName: vscode.env.appName,
+    getTitleBarStyle: () => windowConfig().get<string>('titleBarStyle'),
+    getDismissed: () => context.globalState.get(CURSOR_COMPAT_DISMISSED_KEY, false),
+    setDismissed: (value) => context.globalState.update(CURSOR_COMPAT_DISMISSED_KEY, value),
+    setTitleBarStyle: (value) => windowConfig().update('titleBarStyle', value, vscode.ConfigurationTarget.Global),
+    showInfo: (message, ...items) => vscode.window.showInformationMessage(message, ...items),
+  });
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ const CURSOR_COMPAT_DISMISSED_KEY = 'cursorTitleBarNotificationDismissed';
 
 export function activate(context: vscode.ExtensionContext) {
   if (!vscode.workspace.workspaceFolders) {
+    // No open project, no Git repository.
     return;
   }
   const pollingInterval = vscode.workspace

--- a/src/test/suite/cursorCompat.test.ts
+++ b/src/test/suite/cursorCompat.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2020 WiseTime. All rights reserved.
+
+import * as assert from 'assert';
+import showCursorTitleBarNotification, { shouldShowNotification, NotificationDeps } from '../../cursorCompat';
+
+function makeDeps(overrides: Partial<NotificationDeps> = {}): NotificationDeps {
+  return {
+    appName: 'Cursor',
+    getTitleBarStyle: () => 'custom',
+    getDismissed: () => false,
+    setDismissed: () => Promise.resolve(),
+    setTitleBarStyle: () => Promise.resolve(),
+    showInfo: () => Promise.resolve(undefined),
+    ...overrides,
+  };
+}
+
+suite('Cursor Compat Test Suite', () => {
+
+  suite('shouldShowNotification', () => {
+    test('should return true when running in Cursor with non-native title bar and not dismissed', () => {
+      assert.strictEqual(shouldShowNotification(makeDeps()), true);
+    });
+
+    test('should return false when not running in Cursor', () => {
+      assert.strictEqual(shouldShowNotification(makeDeps({ appName: 'Visual Studio Code' })), false);
+    });
+
+    test('should return false when title bar is already native', () => {
+      assert.strictEqual(shouldShowNotification(makeDeps({ getTitleBarStyle: () => 'native' })), false);
+    });
+
+    test('should return false when notification was previously dismissed', () => {
+      assert.strictEqual(shouldShowNotification(makeDeps({ getDismissed: () => true })), false);
+    });
+  });
+
+  suite('showCursorTitleBarNotification', () => {
+    test('should not show notification when not in Cursor', () => {
+      let shown = false;
+      showCursorTitleBarNotification(makeDeps({
+        appName: 'Visual Studio Code',
+        showInfo: () => { shown = true; return Promise.resolve(undefined); },
+      }));
+      assert.strictEqual(shown, false);
+    });
+
+    test('should show notification when conditions are met', () => {
+      let shown = false;
+      showCursorTitleBarNotification(makeDeps({
+        showInfo: () => { shown = true; return Promise.resolve(undefined); },
+      }));
+      assert.strictEqual(shown, true);
+    });
+
+    test('should set title bar to native when user clicks switch action', done => {
+      let titleBarValue: string | undefined;
+      showCursorTitleBarNotification(makeDeps({
+        showInfo: (message, ...items) => {
+          return Promise.resolve(items[0]);
+        },
+        setTitleBarStyle: (value) => {
+          titleBarValue = value;
+          return Promise.resolve();
+        },
+        setDismissed: () => {
+          assert.strictEqual(titleBarValue, 'native');
+          done();
+          return Promise.resolve();
+        },
+      }));
+    });
+
+    test('should persist dismissal when user clicks dismiss action', done => {
+      let dismissed = false;
+      showCursorTitleBarNotification(makeDeps({
+        showInfo: (_message, ...items) => {
+          return Promise.resolve(items[1]);
+        },
+        setTitleBarStyle: () => {
+          assert.fail('setTitleBarStyle should not be called');
+          return Promise.resolve();
+        },
+        setDismissed: (value) => {
+          dismissed = value;
+          done();
+          return Promise.resolve();
+        },
+      }));
+      assert.strictEqual(dismissed, false, 'not yet dismissed before promise resolves');
+    });
+
+    test('should not persist dismissal when user closes notification without action', done => {
+      let setDismissedCalled = false;
+      showCursorTitleBarNotification(makeDeps({
+        showInfo: () => Promise.resolve(undefined),
+        setDismissed: () => {
+          setDismissedCalled = true;
+          return Promise.resolve();
+        },
+      }));
+      setTimeout(() => {
+        assert.strictEqual(setDismissedCalled, false);
+        done();
+      }, 50);
+    });
+  });
+});

--- a/src/test/suite/cursorCompat.test.ts
+++ b/src/test/suite/cursorCompat.test.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WiseTime. All rights reserved.
+// Copyright (c) 2026 WiseTime. All rights reserved.
 
 import * as assert from 'assert';
 import showCursorTitleBarNotification, { shouldShowNotification, NotificationDeps } from '../../cursorCompat';


### PR DESCRIPTION
## Summary

- Detect when the extension is running in [Cursor](https://cursor.com) with the default custom title bar, which does not display the `window.title` setting
- Show a one-time notification offering to switch to the native title bar style, which correctly renders the window title (and makes the branch name visible to external tools like WiseTime)
- The notification is persisted via `globalState` so it only appears once and can be permanently dismissed
- Add a "Cursor IDE Compatibility" section to the README documenting the workaround
<img width="926" height="159" alt="image" src="https://github.com/user-attachments/assets/0c471704-5def-452f-97be-63da5cd4a25e" />

## Context

Cursor is a popular VS Code fork whose custom title bar ignores the `window.title` setting ([Cursor forum report](https://forum.cursor.com/t/custom-titlebar-ignores-window-title-setting/145945)). This means the branch name injected by this extension is not visible in the title bar, and external tools that read the OS window title (like WiseTime) cannot detect the branch.

Switching to `"window.titleBarStyle": "native"` restores the standard macOS/Windows/Linux title bar behavior, which correctly reflects the `window.title` setting.

## Test plan

- [x] Install in VS Code — verify no notification appears and extension works as before
- [x] Install in Cursor with default (custom) title bar — verify the notification appears offering to switch to native title bar
- [x] Click "Use Native Title Bar" — verify `window.titleBarStyle` is set to `native` in user settings and a restart prompt appears
- [x] Click "Don't Show Again" — verify the notification does not reappear on subsequent activations
- [x] Dismiss without clicking either button — verify the notification reappears on next activation
- [x] With native title bar in Cursor — verify the branch name appears in the window title as expected

## Publication

Please consider publishing to https://open-vsx.org/ so that Cursor users can more easily install this extension.
In the meantime, our workaround is to download it from https://marketplace.visualstudio.com/items?itemName=wisetime.branch-in-window-title and then run `cursor --install-extension branch-in-window-title-0.1.0.vsix`

## Attribution

Code by Cursor/Claude,  intent, testing, and assessment by human me.